### PR TITLE
Release 0.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
           RUSTDOCFLAGS: -D warnings
 
   msrv:
-    name: MSRV (1.89)
+    name: MSRV (1.93.1)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -195,7 +195,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.89"
+          toolchain: "1.93.1"
 
       - name: Cache cargo registry
         uses: actions/cache@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **workspace**: MSRV raised from 1.89 to 1.93.1. `postgres_rustls` 0.1.5 raised
+  its own `rust-version` to 1.93.1 in a patch release, so cargo's resolver
+  rejects the workspace under rustc 1.89 and the MSRV CI job fails. v0.11.2
+  shipped in that state — `rust-version = "1.89"` against a `=0.1.5` pin — so
+  the released tag does not build on its own declared minimum. Raising the
+  floor fixes it without freezing a TLS dependency at 0.1.4 (MSRV 1.86), which
+  was the alternative. The floor is 1.93.1, not 1.93: cargo reads `1.93` as
+  1.93.0, which `postgres_rustls` still rejects.
+
 ## [0.11.2] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [0.12.0] - 2026-08-22
 
-- **workspace**: MSRV raised from 1.89 to 1.93.1. `postgres_rustls` 0.1.5 raised
-  its own `rust-version` to 1.93.1 in a patch release, so cargo's resolver
-  rejects the workspace under rustc 1.89 and the MSRV CI job fails. v0.11.2
-  shipped in that state — `rust-version = "1.89"` against a `=0.1.5` pin — so
-  the released tag does not build on its own declared minimum. Raising the
-  floor fixes it without freezing a TLS dependency at 0.1.4 (MSRV 1.86), which
-  was the alternative. The floor is 1.93.1, not 1.93: cargo reads `1.93` as
-  1.93.0, which `postgres_rustls` still rejects.
+### Breaking
 
-## [0.11.2] - 2026-08-22
+- **workspace**: MSRV raised from 1.89 to 1.93.1, which is why this release is
+  0.12.0 rather than the 0.11.2 it was prepared as. `postgres_rustls` 0.1.5
+  raised its own `rust-version` to 1.93.1 in a patch release, and the `tls`
+  feature pins it exactly, so cargo's resolver rejects the workspace under
+  rustc 1.89. Raising the floor keeps the crate on a supported TLS stack; the
+  alternative was freezing `postgres_rustls` at 0.1.4 (MSRV 1.86). The floor is
+  1.93.1 and not 1.93 because cargo reads `1.93` as 1.93.0, which
+  `postgres_rustls` still rejects.
+
+  0.11.2 was tagged and merged but never published, so no released version ever
+  carried the inconsistent `rust-version = "1.89"` against a `=0.1.5` pin.
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Then create a Pull Request on GitHub targeting `develop`.
 
 ### Prerequisites
 
-- Rust 1.89+ (2024 edition)
+- Rust 1.93.1+ (2024 edition)
 - Docker (for database testing)
 - PostgreSQL, MySQL, or SQLite (for local testing)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "prax-actix"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -4504,7 +4504,7 @@ dependencies = [
 
 [[package]]
 name = "prax-armature"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "prax-axum"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "prax-cassandra"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "cdrs-tokio",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "prax-codegen"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "convert_case 0.6.0",
  "insta",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "prax-duckdb"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "prax-import"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "convert_case 0.6.0",
  "criterion 0.5.1",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "prax-migrate"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "prax-mongodb"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bson",
@@ -4672,7 +4672,7 @@ dependencies = [
 
 [[package]]
 name = "prax-mssql"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bb8",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "prax-mysql"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4718,7 +4718,7 @@ dependencies = [
 
 [[package]]
 name = "prax-orm"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "bson",
  "cargo-husky",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "prax-orm-cli"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "prax-pgvector"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "half",
  "pgvector",
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "prax-postgres"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "prax-query"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "prax-schema"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "criterion 0.8.2",
  "indexmap",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "prax-scylladb"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "prax-sqlite"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "prax-sqlx"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4963,7 +4963,7 @@ dependencies = [
 
 [[package]]
 name = "prax-typegen"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "clap",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.11.2"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.93.1"
 authors = ["Joseph Quinn <quinn.josephr@protonmail.com>"]
@@ -34,25 +34,25 @@ homepage = "https://github.com/quinnjr/prax"
 
 [workspace.dependencies]
 # Internal crates
-prax-schema = { path = "prax-schema", version = "0.11.2" }
-prax-codegen = { path = "prax-codegen", version = "0.11.2" }
-prax-query = { path = "prax-query", version = "0.11.2" }
-prax-postgres = { path = "prax-postgres", version = "0.11.2" }
-prax-mysql = { path = "prax-mysql", version = "0.11.2" }
-prax-sqlite = { path = "prax-sqlite", version = "0.11.2" }
-prax-mssql = { path = "prax-mssql", version = "0.11.2" }
-prax-mongodb = { path = "prax-mongodb", version = "0.11.2" }
-prax-duckdb = { path = "prax-duckdb", version = "0.11.2" }
-prax-scylladb = { path = "prax-scylladb", version = "0.11.2" }
-prax-cassandra = { path = "prax-cassandra", version = "0.11.2" }
-prax-migrate = { path = "prax-migrate", version = "0.11.2" }
-prax-orm-cli = { path = "prax-cli", version = "0.11.2" }
-prax-sqlx = { path = "prax-sqlx", version = "0.11.2" }
-prax-armature = { path = "prax-armature", version = "0.11.2" }
-prax-axum = { path = "prax-axum", version = "0.11.2" }
-prax-actix = { path = "prax-actix", version = "0.11.2" }
-prax-import = { path = "prax-import", version = "0.11.2" }
-prax-pgvector = { path = "prax-pgvector", version = "0.11.2" }
+prax-schema = { path = "prax-schema", version = "0.12.0" }
+prax-codegen = { path = "prax-codegen", version = "0.12.0" }
+prax-query = { path = "prax-query", version = "0.12.0" }
+prax-postgres = { path = "prax-postgres", version = "0.12.0" }
+prax-mysql = { path = "prax-mysql", version = "0.12.0" }
+prax-sqlite = { path = "prax-sqlite", version = "0.12.0" }
+prax-mssql = { path = "prax-mssql", version = "0.12.0" }
+prax-mongodb = { path = "prax-mongodb", version = "0.12.0" }
+prax-duckdb = { path = "prax-duckdb", version = "0.12.0" }
+prax-scylladb = { path = "prax-scylladb", version = "0.12.0" }
+prax-cassandra = { path = "prax-cassandra", version = "0.12.0" }
+prax-migrate = { path = "prax-migrate", version = "0.12.0" }
+prax-orm-cli = { path = "prax-cli", version = "0.12.0" }
+prax-sqlx = { path = "prax-sqlx", version = "0.12.0" }
+prax-armature = { path = "prax-armature", version = "0.12.0" }
+prax-axum = { path = "prax-axum", version = "0.12.0" }
+prax-actix = { path = "prax-actix", version = "0.12.0" }
+prax-import = { path = "prax-import", version = "0.12.0" }
+prax-pgvector = { path = "prax-pgvector", version = "0.12.0" }
 
 # Code generation (proc-macros)
 proc-macro2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["fuzz"]
 [workspace.package]
 version = "0.11.2"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.93.1"
 authors = ["Joseph Quinn <quinn.josephr@protonmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/quinnjr/prax"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://crates.io/crates/prax-orm"><img src="https://img.shields.io/crates/v/prax-orm.svg" alt="crates.io"></a>
   <a href="https://docs.rs/prax-orm"><img src="https://docs.rs/prax-orm/badge.svg" alt="docs.rs"></a>
   <a href="https://github.com/quinnjr/prax/actions"><img src="https://github.com/quinnjr/prax/workflows/CI/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/rust-1.89%2B-blue.svg" alt="Rust 1.89+">
+  <img src="https://img.shields.io/badge/rust-1.93.1%2B-blue.svg" alt="Rust 1.93.1+">
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg" alt="License"></a>
 </p>
 

--- a/prax-postgres/Cargo.toml
+++ b/prax-postgres/Cargo.toml
@@ -58,7 +58,11 @@ lru = { workspace = true }
 # and mysql_async all use rustls). `postgres_rustls` provides the
 # `MakeTlsConnect` impl deadpool-postgres needs; `webpki-roots` supplies the
 # Mozilla root store certificates are verified against.
-# Pinned: 0.1.6 requires rustc > 1.89 (workspace MSRV); re-verify on MSRV bump.
+# Pinned to =0.1.5, the newest release inside the workspace MSRV of 1.93.1:
+# 0.1.5 raised its own rust-version to 1.93.1 (which is why the workspace MSRV
+# is 1.93.1 and not 1.93) and 0.1.6 went further to 1.97.0. Exact rather than a
+# range, so a future patch release cannot raise our MSRV on our behalf.
+# Re-verify on an MSRV bump.
 postgres_rustls = { version = "=0.1.5", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 rustls = { version = "0.23", optional = true }


### PR DESCRIPTION
Release branch for **0.12.0**.

Ships the postgres `sslrootcert` support from #129 together with the MSRV raise from `7dc4fd1`.

## Why 0.12.0 and not 0.11.2

The MSRV raise (1.89 → 1.93.1) is breaking for consumers, which does not belong under a patch version. 0.11.2 was prepared and merged to `main` but **never published**, so its contents ship here instead — meaning no released version ever carried the inconsistent `rust-version = "1.89"` against a `=0.1.5` `postgres_rustls` pin.

## Contents

**`sslrootcert` support** — verification has always been against `webpki-roots`, and there is no encrypt-without-verify mode, so a server behind a privately-signed CA could not be reached at all. Amazon RDS is the common case: its `rds-ca-*` authorities are Amazon-operated and absent from the Mozilla store, so with `rds.force_ssl` on, every `sslmode` failed — the TLS-requiring ones on chain verification, the plaintext ones by server refusal.

Available as a URL parameter, a `PgConfig` field and a builder setter. The bundle replaces the webpki roots rather than adding to them, matching libpq. Bad bundles fail at pool construction naming the file, rather than as an opaque handshake error later. `make_tls_connector()` is unchanged, so `prax-cli` is unaffected.

Verified against a live RDS endpoint: `unable to get local issuer certificate` against system roots, `Verification: OK` against the RDS bundle, hostname included.

**MSRV 1.93.1** — `postgres_rustls` 0.1.5 raised its own `rust-version` in a patch release and the `tls` feature pins it exactly. Raising the floor keeps the crate on a supported TLS stack; the alternative was freezing at 0.1.4 (MSRV 1.86). The floor is 1.93.1 rather than 1.93 because cargo reads `1.93` as 1.93.0, which `postgres_rustls` still rejects.

## Release mechanics

The version bump was applied by hand, not through `scripts/release.sh`. On the 0.11.2 attempt that script also rewrote the deliberately pinned `postgres_rustls` version and pulled unrelated `windows-sys` upgrades into `Cargo.lock` — the diff was misleading enough that I reverted a real MSRV fix believing it was script noise. Worth fixing the script separately.

The diff here is only the `0.11.2` → `0.12.0` bumps in `Cargo.toml`, the matching `Cargo.lock` entries, and the CHANGELOG.

A `--dry-run` of `scripts/publish.sh` reaches upload for Tier 1 and stops at Tier 2 on `failed to select a version for the requirement prax-schema = "^0.12.0"` — expected, since a dry run does not upload Tier 1 for Tier 2 to resolve against. A real run publishes tier by tier and waits for the index between them.