### PR TITLE
release: back-merge v0.12.1 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [0.12.0] - 2026-08-22
 
-- **workspace**: MSRV raised from 1.89 to 1.93.1. `postgres_rustls` 0.1.5 raised
-  its own `rust-version` to 1.93.1 in a patch release, so cargo's resolver
-  rejects the workspace under rustc 1.89 and the MSRV CI job fails. v0.11.2
-  shipped in that state — `rust-version = "1.89"` against a `=0.1.5` pin — so
-  the released tag does not build on its own declared minimum. Raising the
-  floor fixes it without freezing a TLS dependency at 0.1.4 (MSRV 1.86), which
-  was the alternative. The floor is 1.93.1, not 1.93: cargo reads `1.93` as
-  1.93.0, which `postgres_rustls` still rejects.
+### Breaking
 
-## [0.11.2] - 2026-08-22
+- **workspace**: MSRV raised from 1.89 to 1.93.1, which is why this release is
+  0.12.0 rather than the 0.11.2 it was prepared as. `postgres_rustls` 0.1.5
+  raised its own `rust-version` to 1.93.1 in a patch release, and the `tls`
+  feature pins it exactly, so cargo's resolver rejects the workspace under
+  rustc 1.89. Raising the floor keeps the crate on a supported TLS stack; the
+  alternative was freezing `postgres_rustls` at 0.1.4 (MSRV 1.86). The floor is
+  1.93.1 and not 1.93 because cargo reads `1.93` as 1.93.0, which
+  `postgres_rustls` still rejects.
+
+  0.11.2 was tagged and merged but never published, so no released version ever
+  carried the inconsistent `rust-version = "1.89"` against a `=0.1.5` pin.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "prax-actix"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -4504,7 +4504,7 @@ dependencies = [
 
 [[package]]
 name = "prax-armature"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "prax-axum"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "prax-cassandra"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "cdrs-tokio",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "prax-codegen"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "convert_case 0.6.0",
  "insta",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "prax-duckdb"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "prax-import"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "convert_case 0.6.0",
  "criterion 0.5.1",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "prax-migrate"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "prax-mongodb"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bson",
@@ -4672,7 +4672,7 @@ dependencies = [
 
 [[package]]
 name = "prax-mssql"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bb8",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "prax-mysql"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4718,7 +4718,7 @@ dependencies = [
 
 [[package]]
 name = "prax-orm"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "bson",
  "cargo-husky",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "prax-orm-cli"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "prax-pgvector"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "half",
  "pgvector",
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "prax-postgres"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "prax-query"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "prax-schema"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "criterion 0.8.2",
  "indexmap",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "prax-scylladb"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "prax-sqlite"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "prax-sqlx"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4963,7 +4963,7 @@ dependencies = [
 
 [[package]]
 name = "prax-typegen"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "clap",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.11.2"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.93.1"
 authors = ["Joseph Quinn <quinn.josephr@protonmail.com>"]
@@ -34,25 +34,25 @@ homepage = "https://github.com/quinnjr/prax"
 
 [workspace.dependencies]
 # Internal crates
-prax-schema = { path = "prax-schema", version = "0.11.2" }
-prax-codegen = { path = "prax-codegen", version = "0.11.2" }
-prax-query = { path = "prax-query", version = "0.11.2" }
-prax-postgres = { path = "prax-postgres", version = "0.11.2" }
-prax-mysql = { path = "prax-mysql", version = "0.11.2" }
-prax-sqlite = { path = "prax-sqlite", version = "0.11.2" }
-prax-mssql = { path = "prax-mssql", version = "0.11.2" }
-prax-mongodb = { path = "prax-mongodb", version = "0.11.2" }
-prax-duckdb = { path = "prax-duckdb", version = "0.11.2" }
-prax-scylladb = { path = "prax-scylladb", version = "0.11.2" }
-prax-cassandra = { path = "prax-cassandra", version = "0.11.2" }
-prax-migrate = { path = "prax-migrate", version = "0.11.2" }
-prax-orm-cli = { path = "prax-cli", version = "0.11.2" }
-prax-sqlx = { path = "prax-sqlx", version = "0.11.2" }
-prax-armature = { path = "prax-armature", version = "0.11.2" }
-prax-axum = { path = "prax-axum", version = "0.11.2" }
-prax-actix = { path = "prax-actix", version = "0.11.2" }
-prax-import = { path = "prax-import", version = "0.11.2" }
-prax-pgvector = { path = "prax-pgvector", version = "0.11.2" }
+prax-schema = { path = "prax-schema", version = "0.12.0" }
+prax-codegen = { path = "prax-codegen", version = "0.12.0" }
+prax-query = { path = "prax-query", version = "0.12.0" }
+prax-postgres = { path = "prax-postgres", version = "0.12.0" }
+prax-mysql = { path = "prax-mysql", version = "0.12.0" }
+prax-sqlite = { path = "prax-sqlite", version = "0.12.0" }
+prax-mssql = { path = "prax-mssql", version = "0.12.0" }
+prax-mongodb = { path = "prax-mongodb", version = "0.12.0" }
+prax-duckdb = { path = "prax-duckdb", version = "0.12.0" }
+prax-scylladb = { path = "prax-scylladb", version = "0.12.0" }
+prax-cassandra = { path = "prax-cassandra", version = "0.12.0" }
+prax-migrate = { path = "prax-migrate", version = "0.12.0" }
+prax-orm-cli = { path = "prax-cli", version = "0.12.0" }
+prax-sqlx = { path = "prax-sqlx", version = "0.12.0" }
+prax-armature = { path = "prax-armature", version = "0.12.0" }
+prax-axum = { path = "prax-axum", version = "0.12.0" }
+prax-actix = { path = "prax-actix", version = "0.12.0" }
+prax-import = { path = "prax-import", version = "0.12.0" }
+prax-pgvector = { path = "prax-pgvector", version = "0.12.0" }
 
 # Code generation (proc-macros)
 proc-macro2 = "1.0"


### PR DESCRIPTION
Back-merge of release/0.12.1 into develop per git-flow, carrying the 0.12.0→0.12.1 version bump and the reconciliation of main into develop (0.12.0 had shipped from main without a back-merge). Crates already published at 0.12.1.